### PR TITLE
Refactor(Address) address_line_1 field not reqd

### DIFF
--- a/frappe/contacts/doctype/address/address.json
+++ b/frappe/contacts/doctype/address/address.json
@@ -50,8 +50,7 @@
   {
    "fieldname": "address_line1",
    "fieldtype": "Data",
-   "label": "Address Line 1",
-   "reqd": 1
+   "label": "Address Line 1"
   },
   {
    "fieldname": "address_line2",
@@ -148,7 +147,7 @@
  "icon": "fa fa-map-marker",
  "idx": 5,
  "links": [],
- "modified": "2020-10-21 16:14:37.284830",
+ "modified": "2022-09-20 00:11:38.521094",
  "modified_by": "Administrator",
  "module": "Contacts",
  "name": "Address",


### PR DESCRIPTION
Re : https://app.clickup.com/t/3duwq3m

**Issue:** 
--
When creating a lead doctype, address_line_1 is triggering an error requiring the "address_line_1" to be mandatory, even when it's not.

This is due to when saving a Lead doctype it also creates an "address" doctype. In the address doctype the "address_line_1 is required.

**Solution:**
--
Set the property of the field ('address_line_1') in the address doctype to not required.